### PR TITLE
Bugfix for duplicate ADO items

### DIFF
--- a/.github/workflows/syncToDevOps.yml
+++ b/.github/workflows/syncToDevOps.yml
@@ -3,7 +3,7 @@ name: Sync issue to Azure DevOps work item
 "on":
   issues:
     types:
-      [opened, edited, deleted, closed, reopened, labeled, unlabeled]
+      [opened, reopened]
 
 jobs:
   alert:


### PR DESCRIPTION
sync issues only when a GitHub issue is opened or reopened

# Thank you for helping us improve the Azure IoT Python SDK!

## Need Support

- **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize
- **Have a technical question?** Please see [IoT support options](https://aka.ms/IoTHelp) for information on posting questions on Microsoft Q&A and Stack overflow using the "azure-iot-sdk" tag.
- **Need Support?** Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- **Found a bug?** Please help us fix it by thoroughly documenting it and filing an issue on GitHub (See below).

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

## Checklist

- [] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-python/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

## Reference/Link to the issue solved with this PR (if any)

## Description of the problem

Please be as precise as possible: what issue you experienced, how often...

## Description of the solution

How you solved the issue and the other things you considered and maybe rejected
